### PR TITLE
Add support for CF955AX (3574:6121)

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -157,6 +157,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_REALTEK, 0xA85B, 0xff, 0xff, 0xff), .driver_info = RTL8852B},
 	{USB_DEVICE_AND_INTERFACE_INFO(0x0586, 0x3428, 0xff, 0xff, 0xff), .driver_info = RTL8852B},
 	{USB_DEVICE_AND_INTERFACE_INFO(0x0b05, 0x1a62, 0xff, 0xff, 0xff), .driver_info = RTL8852B},	
+	{USB_DEVICE_AND_INTERFACE_INFO(0x3574, 0x6121, 0xff, 0xff, 0xff), .driver_info = RTL8852B},
 #endif /* CONFIG_RTL8852B */
 
 #ifdef CONFIG_RTL8852BP


### PR DESCRIPTION
I have a CF-955AX adapter which uses the RTL8832BU chip, but the device ID is 3574:6121 (not the realtek one) which is not included in this driver's supported devices.

I have added the ID to `os_dep/linux/usb_intf.c`. Not sure if this is the right thing to do but at least it works in my environment (Pop-OS 22.04 based on Ubuntu with kernel 6.5)