### PR TITLE
Add support for EDIMAX ED-7822UMX (7392:6822)

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -158,6 +158,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE_AND_INTERFACE_INFO(0x0586, 0x3428, 0xff, 0xff, 0xff), .driver_info = RTL8852B},
 	{USB_DEVICE_AND_INTERFACE_INFO(0x0b05, 0x1a62, 0xff, 0xff, 0xff), .driver_info = RTL8852B},	
 	{USB_DEVICE_AND_INTERFACE_INFO(0x3574, 0x6121, 0xff, 0xff, 0xff), .driver_info = RTL8852B},
+	{USB_DEVICE_AND_INTERFACE_INFO(0x7392, 0x6822, 0xff, 0xff, 0xff), .driver_info = RTL8852B}, // EDIMAX EW-7822UMX
 #endif /* CONFIG_RTL8852B */
 
 #ifdef CONFIG_RTL8852BP


### PR DESCRIPTION
add device number only for ED-7822UMX.

It functions as expected with no discernible impact on transfer speeds.

closes #14 