### PR TITLE
Adding AKMBUILD for "akms" / alpine dkms support

### DIFF
--- a/AKMBUILD
+++ b/AKMBUILD
@@ -1,0 +1,11 @@
+modname=rtl8852bu
+modver=git
+built_modules='8852bu.ko'
+
+build() {
+  cp -R "$srcdir"/* "$builddir"/
+  cd "$builddir"  
+  make
+  #touch "$builddir"/Makefile
+  #make $MAKEFLAGS -C "$kernel_srcdir" M="$builddir" src="$srcdir"
+}


### PR DESCRIPTION
:wave:  Hello,

this adds support for a AKMS file (basically DKMS for alpine), so we don't forget to build the driver when a new kernel hits. :-)

Feel free to change any values in the file, it's just a minimalist build file.