### PR TITLE
Add support for netns

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -10331,6 +10331,7 @@ static int rtw_cfg80211_init_wiphy(_adapter *adapter, struct wiphy *wiphy)
 	wiphy->max_num_csa_counters = MAX_CSA_CNT;
 #endif
 #endif /* CONFIG_ECSA_PHL */
+	wiphy->flags |= WIPHY_FLAG_NETNS_OK;
 
 	ret = _SUCCESS;
 

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -663,6 +663,7 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 	rtw_init_netdev_name(ndev, name);
 
 	dev_addr_mod(ndev, 0, adapter_mac_addr(adapter), ETH_ALEN);
+	dev_net_set(ndev, wiphy_net(adapter_to_wiphy(adapter)));
 
 	/* Tell the network stack we exist */
 


### PR DESCRIPTION
Added  [netns support](https://github.com/morrownr/rtl8852bu/issues/13) to the driver.